### PR TITLE
Fixed bug on number of classes calculation

### DIFF
--- a/src/__tests__/utilsTest.js
+++ b/src/__tests__/utilsTest.js
@@ -25,4 +25,10 @@ describe('Utils', () => {
       Utils.getNumberOfClasses([0, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     ).toBe(10);
   });
+
+  it('Get number of classes without the first class', () => {
+    expect(
+      Utils.getNumberOfClasses([1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    ).toBe(10);
+  });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,13 +50,13 @@ export function giniImpurity(array) {
 export function getNumberOfClasses(array) {
   return array.filter(function (val, i, arr) {
     return arr.indexOf(val) === i;
-  }).length;
+  }).map((val) => val + 1).reduce((a, b) => Math.max(a, b));
 }
 
 /**
  * @private
  * Calculates the Gini Gain of an array of predictions and those predictions splitted by a feature.
- * @para {Array} array - Predictions
+ * @param {Array} array - Predictions
  * @param {object} splitted - Object with elements "greater" and "lesser" that contains an array of predictions splitted.
  * @return {number} - Gini Gain.
  */


### PR DESCRIPTION
The current calculation of the number of classes in arrays is resulting in multiple errors that result in lower overall accuracies, the changes made in this pull request are to ensure that the number of classes returned from the `getNumberOfClasses` function is correct

What was the thought process behind the changes?
- If you have an array with 9 classes, going from 1 to 9, we can assume the array has 10 classes and that class 0 just isn't in that sample

Why was this a problem?
- Currently, if the `getNumberOfClasses` function receives an array missing a class before the highest class, then it only returns the length of the resulting array without the repetitions. So in the case of an array `[1, 2]` the return would be 2, but the actual number of classes would need to be 3.

- The `toDiscreteDistribution` function receives an array (we'll call it A) and a `numberOfClasses` integer, the function then creates another array (we'll call it B) of size `numberOfClasses` (which currently is always the return of a `getNumberOfClasses` function called on A), then fills B in indexes based on the classes contained in A, so if the first classes are omitted, then the indexes filled in B would result in a NaN in the last (or the last couple) of indexes of B. For example, if A is `[1, 2]` in the `toDiscreteDistribution` function, then the indexes filled in B would be 1 and 2, but B would only be size 2, as established before, and therefore wouldn't have an index 2, resulting in a value of NaN in index 2