### PR TITLE
Fix empty array

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,7 @@ export function giniImpurity(array) {
  */
 export function getNumberOfClasses(array) {
   return array
-    .filter(function(val, i, arr) {
+    .filter(function (val, i, arr) {
       return arr.indexOf(val) === i;
     })
     .map((val) => val + 1)
@@ -110,7 +110,8 @@ export function regressionError(array, splitted) {
 
   for (let i = 0; i < splits.length; ++i) {
     let currentSplit = splitted[splits[i]];
-    error += squaredError(currentSplit);
+    if (currentSplit.length > 0)
+      error += squaredError(currentSplit);
   }
   return error;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,6 +85,7 @@ export function giniGain(array, splitted) {
  */
 export function squaredError(array) {
   let l = array.length;
+  if (l === 0) { return 0.0; }
 
   let m = meanArray(array);
   let error = 0.0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,8 +111,7 @@ export function regressionError(array, splitted) {
 
   for (let i = 0; i < splits.length; ++i) {
     let currentSplit = splitted[splits[i]];
-    if (currentSplit.length > 0)
-      error += squaredError(currentSplit);
+    error += squaredError(currentSplit);
   }
   return error;
 }


### PR DESCRIPTION
Hi,
in the example below, an error occurs, because the array 'currentSplit' is empty. Maby an investigation would be good, why it is empty, but I have not enough time currently. 

this example is a test case from the mljs/random-forest package (src/__tests__/regressionTest.js):
```javascript
//import { DecisionTreeRegression as DTRegression } from 'ml-cart';
const DTRegression = require('ml-cart').DecisionTreeRegression;
let dataset = [
    [73.0, 80.0, 75.0, 152.0],
    [93, 88, 93, 185],
    [89, 91, 90, 180],
    [96, 98, 100, 196],
    [73, 66, 70, 142],
    [53, 46, 55, 101],
    [69, 74, 77, 149],
    [47, 56, 60, 115],
    [87, 79, 90, 175],
    [79, 70, 88, 164],
    [69, 70, 73, 141],
    [70, 65, 74, 141],
    [93, 95, 91, 184],
    [79, 80, 73, 152],
    [70, 73, 78, 148],
    [93, 89, 96, 192],
    [78, 75, 68, 147],
    [81, 90, 93, 183],
    [88, 92, 86, 177],
    [78, 83, 77, 159],
    [82, 86, 90, 177],
    [86, 82, 89, 175],
    [78, 83, 85, 175],
    [76, 83, 71, 149],
    [96, 93, 95, 192],
  ];
  
  const n = dataset.length;
  let trainingSet = new Array(n);
  let predictions = new Array(n);
  
  for (let i = 0; i < n; ++i) {
    trainingSet[i] = dataset[i].slice(0,3);
    predictions[i] = dataset[i][3];
  }

  console.log(trainingSet)
  console.log(predictions)
var reg = new DTRegression();
reg.train(trainingSet, predictions);
var estimations = reg.predict(trainingSet);
console.log(estimations);
```