### PR TITLE
fix: changes to fix issues 9, 15, 17, 28, 32 in random-forest 

### DIFF
--- a/src/DecisionTreeClassifier.js
+++ b/src/DecisionTreeClassifier.js
@@ -1,4 +1,4 @@
-import Matrix from 'ml-matrix';
+import { Matrix } from 'ml-matrix';
 
 import Tree from './TreeNode';
 

--- a/src/DecisionTreeRegression.js
+++ b/src/DecisionTreeRegression.js
@@ -1,4 +1,4 @@
-import Matrix from 'ml-matrix';
+import { Matrix } from 'ml-matrix';
 
 import Tree from './TreeNode';
 

--- a/src/TreeNode.js
+++ b/src/TreeNode.js
@@ -1,5 +1,5 @@
 import mean from 'ml-array-mean';
-import Matrix from 'ml-matrix';
+import { Matrix } from 'ml-matrix';
 
 import * as Utils from './utils';
 
@@ -27,7 +27,7 @@ export default class TreeNode {
     this.minNumSamples = options.minNumSamples;
     this.maxDepth = options.maxDepth;
 
-    if(!options.gainThreshold) {
+    if (!options.gainThreshold) {
       this.gainThreshold = 0;
     } else {
       this.gainThreshold = options.gainThreshold;
@@ -64,7 +64,7 @@ export default class TreeNode {
           maxColumn = i;
           maxValue = currentSplitVal;
           bestGain = gain;
-          numberSamples = currentFeature.length
+          numberSamples = currentFeature.length;
         }
       }
     }
@@ -113,7 +113,7 @@ export default class TreeNode {
   featureSplit(x, y) {
     let splitValues = [];
     let arr = Utils.zip(x, y);
-    arr.sort(function (a, b) {
+    arr.sort((a, b) => {
       return a[0] - b[0];
     });
 

--- a/src/TreeNode.js
+++ b/src/TreeNode.js
@@ -26,7 +26,12 @@ export default class TreeNode {
     this.splitFunction = options.splitFunction;
     this.minNumSamples = options.minNumSamples;
     this.maxDepth = options.maxDepth;
-    this.gainThreshold = options.gainThreshold;
+
+    if(!options.gainThreshold) {
+      this.gainThreshold = 0;
+    } else {
+      this.gainThreshold = options.gainThreshold;
+    }
   }
 
   /**
@@ -45,6 +50,7 @@ export default class TreeNode {
 
     let maxColumn;
     let maxValue;
+    let numberSamples;
 
     for (let i = 0; i < XTranspose.rows; ++i) {
       let currentFeature = XTranspose.getRow(i);
@@ -58,6 +64,7 @@ export default class TreeNode {
           maxColumn = i;
           maxValue = currentSplitVal;
           bestGain = gain;
+          numberSamples = currentFeature.length
         }
       }
     }
@@ -66,6 +73,7 @@ export default class TreeNode {
       maxGain: bestGain,
       maxColumn: maxColumn,
       maxValue: maxValue,
+      numberSamples: numberSamples,
     };
   }
 
@@ -162,6 +170,7 @@ export default class TreeNode {
     this.splitValue = split.maxValue;
     this.splitColumn = split.maxColumn;
     this.gain = split.maxGain;
+    this.numberSamples = split.numberSamples;
 
     let splittedMatrix = Utils.matrixSplitter(
       X,

--- a/src/TreeNode.js
+++ b/src/TreeNode.js
@@ -26,12 +26,7 @@ export default class TreeNode {
     this.splitFunction = options.splitFunction;
     this.minNumSamples = options.minNumSamples;
     this.maxDepth = options.maxDepth;
-
-    if (!options.gainThreshold) {
-      this.gainThreshold = 0;
-    } else {
-      this.gainThreshold = options.gainThreshold;
-    }
+  this.gainThreshold = options.gainThreshold || 0;
   }
 
   /**

--- a/src/__tests__/classifierTest.js
+++ b/src/__tests__/classifierTest.js
@@ -1,12 +1,12 @@
-import irisDataset from 'ml-dataset-iris';
-import Matrix, { MatrixTransposeView } from 'ml-matrix';
+import { getClasses, getDistinctClasses, getNumbers } from 'ml-dataset-iris';
+import { Matrix, MatrixTransposeView } from 'ml-matrix';
 
 import { DecisionTreeClassifier as DTClassifier } from '..';
 
-let trainingSet = irisDataset.getNumbers();
-let predictions = irisDataset
-  .getClasses()
-  .map((elem) => irisDataset.getDistinctClasses().indexOf(elem));
+let trainingSet = getNumbers();
+let predictions = getClasses().map((elem) =>
+  getDistinctClasses().indexOf(elem),
+);
 
 let options = {
   gainFunction: 'gini',

--- a/src/__tests__/regressionTest.js
+++ b/src/__tests__/regressionTest.js
@@ -1,4 +1,4 @@
-import Matrix, { MatrixTransposeView } from 'ml-matrix';
+import { Matrix, MatrixTransposeView } from 'ml-matrix';
 
 import { DecisionTreeRegression as DTRegression } from '..';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import meanArray from 'ml-array-mean';
-import Matrix from 'ml-matrix';
+import { Matrix } from 'ml-matrix';
 
 /**
  * @private
@@ -49,7 +49,7 @@ export function giniImpurity(array) {
  */
 export function getNumberOfClasses(array) {
   return array
-    .filter(function (val, i, arr) {
+    .filter((val, i, arr) => {
       return arr.indexOf(val) === i;
     })
     .map((val) => val + 1)


### PR DESCRIPTION
In this pull request, the variable this.grainThreshold is initialized to zero if it is undefined in the constructor. I have added variable this.numberSamples in order to be able to use the function featureImportace in the RandomForestRegression and RandomForestClassifier. These changes are in response to open issues in the random-forest repo.

